### PR TITLE
[#3] Unit test configuration using catch2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,113 @@
+# Created by https://www.toptal.com/developers/gitignore/api/clion+all,cmake
+# Edit at https://www.toptal.com/developers/gitignore?templates=clion+all,cmake
+
+### CLion+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### CLion+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+### CMake ###
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+### CMake Patch ###
+# External projects
+*-prefix/
+
+# End of https://www.toptal.com/developers/gitignore/api/clion+all,cmake
+
 proto/proto.pb.o
 proto/*.pb.cc
 proto/*.pb.h

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ proto/*.pb.cc
 proto/*.pb.h
 filesystem/filesystem
 server/server
+
+tests/catch2/**.o
+tests/test-runner

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,18 @@ SERVER_FILES := server/tcp.cpp server/main.cpp
 FS_FILES := filesystem/tcp.cpp filesystem/main.cpp
 PROTO := proto/messages.proto
 
+TEST_FLAGS := `pkg-config --cflags catch2-with-main`
+TEST_LIBS := `pkg-config --libs catch2-with-main`
+TEST_DIR := tests/catch2
+TEST_FILES := $(wildcard $(TEST_DIR)/*.cpp)
+
 all: build
 
 .PHONY: build
-build: filesystem server
+build: filesystem server test-binary
 
 .PHONY: clean
-clean: filesystem-clean server-clean
-
-.PHONY: clean-all
-clean-all: clean proto-clean
+clean: filesystem-clean server-clean proto-clean test-clean
 
 .PHONY: filesystem-run
 filesystem-run: filesystem 
@@ -62,3 +64,15 @@ format:
 
 check-format:
 	clang-format --dry-run --Werror proto/*.proto **/*.h **/*.cpp
+
+.PHONY: test-run
+test-run: test
+	./tests/test-runner
+
+.PHONY: test
+test: $(TEST_FILES) proto/proto.pb.o
+	$(CC) $(C_FLAGS) $(TEST_FLAGS) -o tests/test-runner $(TEST_FILES) $(COMMON) proto/proto.pb.o $(TEST_LIBS)
+
+.PHONY: test-clean
+test-clean:
+	rm -f tests/test-runner

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CC := clang++
-C_FLAGS := -g -Wall -Wextra -pedantic -std=c++20 `pkg-config --cflags --libs protobuf` -pthread
+CC := g++
+C_FLAGS := -g3 -Wall -Wextra -pedantic -std=c++20 `pkg-config --cflags --libs protobuf` -pthread
 FS_FLAGS := -lfuse3 -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=30
 SERVER_FLAGS := 
 COMMON := common/log.cpp common/io.cpp

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ CC := clang++
 C_FLAGS := -g -Wall -Wextra -pedantic -std=c++20 `pkg-config --cflags --libs protobuf` -pthread
 FS_FLAGS := -lfuse3 -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=30
 SERVER_FLAGS := 
-COMMON := common/log.cpp
-SERVER_FILES := 
-FS_FILES :=
-PROTO := proto/packets.proto
+COMMON := common/log.cpp common/io.cpp
+SERVER_FILES := server/tcp.cpp server/main.cpp
+FS_FILES := filesystem/tcp.cpp filesystem/main.cpp
+PROTO := proto/messages.proto
 
 all: build
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # tea
+
+# Testing
+
+In order to run tests you should have a `catch2` test runner installed on your system with version `3.6.0`.
+Then simply navigate to the project root folder and run the make target with name `test-run`
+
+```shell
+make test-run
+```

--- a/common/header.cpp
+++ b/common/header.cpp
@@ -1,0 +1,27 @@
+#include "header.h"
+#include <cstdint>
+
+char *serialize(Header *header) {
+    char *buf = new char[sizeof(Header)];
+    uint32_t nsize = htonl(header->size);
+    uint32_t nid = htonl(header->id);
+    uint32_t ntype = htonl(header->type);
+    memcpy(buf, &nsize, sizeof(int32_t));
+    memcpy(buf + sizeof(int32_t), &nid, sizeof(int32_t));
+    memcpy(buf + sizeof(int32_t) + sizeof(int32_t), &ntype, sizeof(int32_t));
+    return buf;
+}
+
+Header *deserialize(char *buffer) {
+    Header *header = new Header;
+    uint32_t nsize;
+    uint32_t nid;
+    uint32_t ntype;
+    memcpy(&nsize, buffer, sizeof(int32_t));
+    memcpy(&nid, buffer + sizeof(int32_t), sizeof(int32_t));
+    memcpy(&ntype, buffer + sizeof(int32_t) + sizeof(int32_t), sizeof(int32_t));
+    header->size = ntohl(nsize);
+    header->id = ntohl(nid);
+    header->type = ntohl(ntype);
+    return header;
+}

--- a/common/header.h
+++ b/common/header.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <arpa/inet.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+const int HEADER_SIZE = 12;
+
+struct Header {
+    int32_t size;
+    int32_t id;
+    int32_t type;
+};
+
+char *serialize(Header *header);
+
+Header *deserialize(char *buffer);

--- a/common/io.cpp
+++ b/common/io.cpp
@@ -1,0 +1,117 @@
+#include "io.h"
+#include "../proto/messages.pb.h"
+#include "header.h"
+#include "log.h"
+#include <arpa/inet.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <google/protobuf/message.h>
+
+int send_message(int sock, int id, Type type, google::protobuf::Message *body) {
+    Header header;
+    header.size = body->ByteSizeLong();
+    header.id = id;
+    header.type = type;
+
+    char *header_buffer = serialize(&header);
+    char *message_buffer = new char[HEADER_SIZE + body->ByteSizeLong()];
+    memcpy(message_buffer, header_buffer, HEADER_SIZE);
+    delete[] header_buffer;
+
+    char *body_buffer = new char[body->ByteSizeLong()];
+    bool err = body->SerializeToArray(body_buffer, body->ByteSizeLong());
+    if (!err) {
+        log(DEBUG, sock, "(%d) Serialize body failed", id);
+        return -1;
+    }
+    memcpy(message_buffer + HEADER_SIZE, body_buffer, body->ByteSizeLong());
+    delete[] body_buffer;
+
+    int len = send(sock, message_buffer, HEADER_SIZE + body->ByteSizeLong(), 0);
+    if (len < 0) {
+        log(DEBUG, sock, "(%d) Send message failed: %s", id, strerror(errno));
+        return -1;
+    }
+    std::string debug = body->DebugString();
+    debug.pop_back();
+    log(DEBUG, sock, "(%d) Send message success: %s - %d bytes", id, debug.c_str(), len);
+
+    return len;
+}
+
+int full_read(int fd, char *buf, int size) {
+    int recived = 0;
+    while (recived < size) {
+        int len = recv(fd, buf + recived, size - recived, 0);
+        if (len == 0) {
+            log(DEBUG, fd, "EOF");
+            return 0;
+        }
+        if (len < 0) {
+            log(DEBUG, fd, "Full read failed: %s", strerror(errno));
+            return -1;
+        }
+        recived += len;
+    }
+    return recived;
+}
+
+// Handle recv messages, 1 on success, 0 on EOF, -1 on error
+int handle_recv(int sock, recv_handlers &handlers) {
+    Header *header;
+    char buffer[HEADER_SIZE];
+    int recived = full_read(sock, buffer, sizeof(buffer));
+    if (recived == 0) {
+        return 0;
+    }
+    if (recived < (int)sizeof(buffer)) {
+        log(DEBUG, sock, "Full header read failed");
+        return -1;
+    }
+    header = deserialize(buffer);
+    log(DEBUG, sock, "Received header: size %d id %d type %d %d bytes", header->size, header->id, header->type, recived);
+    char *recv_buffer = new char[header->size];
+    recived = full_read(sock, recv_buffer, header->size);
+    if (recived == 0 && header->size != 0) {
+        return 0;
+    }
+    if (recived < header->size) {
+        return -1;
+    }
+    int ret = -2;
+    std::string message = "";
+    switch (header->type) {
+    case Type::INIT_REQUEST: {
+        InitRequest request;
+        request.ParseFromArray(recv_buffer, header->size);
+        message = "InitRequest: ";
+        message = request.DebugString();
+        ret = handlers.init_request(sock, header->id, &request);
+        break;
+    }
+    case Type::INIT_RESPONSE: {
+        InitResponse response;
+        response.ParseFromArray(recv_buffer, header->size);
+        message = "InitResponse: ";
+        message = response.DebugString();
+        ret = handlers.init_response(sock, header->id, &response);
+        break;
+    }
+    default:
+        log(DEBUG, sock, "(%d) Unknown message type: %d", header->id, header->type);
+        break;
+    }
+    if (message != "") {
+        message.pop_back();
+        log(DEBUG, sock, message.c_str());
+    }
+    if (ret < 0) {
+        log(DEBUG, sock, "Handler failed: %d", ret);
+    } else {
+        log(DEBUG, sock, "Handler success: %d", ret);
+    }
+    delete header;
+    delete[] recv_buffer;
+    return ret;
+};

--- a/common/io.h
+++ b/common/io.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "../proto/messages.pb.h"
+#include <arpa/inet.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <google/protobuf/message.h>
+
+int send_message(int sock, int id, Type type, google::protobuf::Message *message);
+
+struct recv_handlers {
+    int (*init_request)(int sock, int id, InitRequest *request);
+    int (*init_response)(int sock, int id, InitResponse *response);
+};
+
+int handle_recv(int sock, recv_handlers &handlers);

--- a/common/packet.proto
+++ b/common/packet.proto
@@ -1,1 +1,0 @@
-syntax = "proto3";

--- a/filesystem/tcp.cpp
+++ b/filesystem/tcp.cpp
@@ -1,0 +1,62 @@
+#include "../common/io.h"
+#include "../common/log.h"
+#include <condition_variable>
+#include <google/protobuf/message.h>
+#include <string>
+
+std::map<int, std::string> messages;
+std::map<int, std::condition_variable> conditions;
+std::map<int, std::mutex> mutexes;
+int requst_id = 0;
+
+template <typename T> int response_handler(int sock, int id, T message) {
+    (void)sock;
+    std::unique_lock<std::mutex> lock(mutexes[id]);
+    messages[id] = message->SerializeAsString();
+    conditions[id].notify_all();
+    lock.unlock();
+    return 0;
+}
+
+template <typename T> int request_handler(int sock, int id, T message) {
+    (void)sock;
+    (void)id;
+    (void)message;
+    return 0;
+}
+
+recv_handlers handlers = {.init_request = request_handler<InitRequest *>, .init_response = response_handler<InitResponse *>};
+
+int connect(std::string host, int port) {
+    int sock;
+    if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+        log(ERROR, sock, "Error creating socket: %s", strerror(errno));
+        return 1;
+    }
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = inet_addr(host.c_str());
+    if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        log(ERROR, sock, "Error connecting to port %d: %s", port, strerror(errno));
+        return 1;
+    }
+    log(INFO, sock, "Connected to port %d", port);
+    return sock;
+}
+
+int recv_thread(int sock) {
+    while (true) {
+        int err = handle_recv(sock, handlers);
+        if (err < 0) {
+            log(ERROR, sock, "Error handling message");
+            return -1;
+        }
+        if (err == 0) {
+            close(sock);
+            log(INFO, sock, "Closing connection");
+            return 0;
+        }
+    }
+    return 1;
+}

--- a/filesystem/tcp.h
+++ b/filesystem/tcp.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "../common/io.h"
+#include <condition_variable>
+#include <mutex>
+#include <string>
+
+extern int requst_id;
+extern std::map<int, std::string> messages;
+extern std::map<int, std::condition_variable> conditions;
+extern std::map<int, std::mutex> mutexes;
+
+int connect(std::string host, int port);
+
+int recv_thread(int sock);
+
+template <typename T> int request_response(int sock, google::protobuf::Message &request, T *response) {
+    int err = send_message(sock, ++requst_id, Type::INIT_REQUEST, &request);
+    if (err < 0) {
+        return -1;
+    }
+    std::unique_lock<std::mutex> lock(mutexes[requst_id]);
+    conditions[requst_id].wait(lock);
+    response->ParseFromString(messages[requst_id]);
+    return 0;
+}

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+enum Type {
+  INIT_REQUEST = 0;
+  INIT_RESPONSE = 1;
+}
+
+message InitRequest { int32 error = 1; }
+
+message InitResponse { int32 error = 1; }

--- a/proto/packets.proto
+++ b/proto/packets.proto
@@ -1,1 +1,0 @@
-syntax = "proto3";

--- a/server/tcp.cpp
+++ b/server/tcp.cpp
@@ -1,0 +1,74 @@
+#include "../common/io.h"
+#include "../common/log.h"
+#include <list>
+#include <thread>
+
+std::list<std::thread> threads;
+std::list<int> clients;
+
+void client_handler(int fd, recv_handlers handlers) {
+    while (true) {
+        int err = handle_recv(fd, handlers);
+        if (err < 0) {
+            log(ERROR, fd, "Error handling message");
+            return;
+        }
+        if (err == 0) {
+            log(INFO, fd, "Closing connection");
+            close(fd);
+            return;
+        }
+    }
+}
+
+int listen(int port, recv_handlers handlers) {
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) {
+        perror("socket");
+        return 1;
+    }
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = INADDR_ANY;
+    constexpr int one = 1;
+    int err = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    if (err < 0) {
+        log(ERROR, sock, "Error setting socket options: %s", strerror(errno));
+        return 1;
+    }
+    if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        log(ERROR, sock, "Error bind port: %s", strerror(errno));
+        return 1;
+    }
+    err = listen(sock, 10);
+    if (err < 0) {
+        log(ERROR, sock, "Error listening: %s", strerror(errno));
+        return 1;
+    }
+    log(INFO, sock, "Listening on port %d", port);
+    struct sockaddr_in client_addr;
+    socklen_t client_addr_len = sizeof(client_addr);
+    while (true) {
+        const int client_sock = accept(sock, (struct sockaddr *)&client_addr, &client_addr_len);
+        if (client_sock < 0) {
+            log(ERROR, sock, "Error accepting connection: %s", strerror(errno));
+            return 1;
+        }
+        clients.push_back(client_sock);
+        log(INFO, client_sock, "Accepted connection from %s:%d", inet_ntoa(client_addr.sin_addr), ntohs(client_addr.sin_port));
+        std::thread t(client_handler, client_sock, handlers);
+        threads.push_back(std::move(t));
+    }
+    return 0;
+}
+
+int close_connections() {
+    for (auto &c : clients) {
+        close(c);
+    }
+    for (auto &t : threads) {
+        t.detach();
+    }
+    return 0;
+}

--- a/server/tcp.h
+++ b/server/tcp.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "../common/io.h"
+#include <string>
+
+int listen(int port, recv_handlers hadnlers);
+
+int close_connections();

--- a/tests/catch2/test_runner_test.cpp
+++ b/tests/catch2/test_runner_test.cpp
@@ -1,0 +1,7 @@
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("A basic test that confirms that tests are run") {
+    SECTION("Basic operations") {
+        REQUIRE(0.1 + 0.2 != 0.3);
+    }
+}


### PR DESCRIPTION
Using packaged `catch2` from a package manager, because manually setting it up using make is too much of a pain. If we ever decide to migrate to cmake, we can consider migrating it to building `catch2` from source.