### PR TITLE
[#2] Add catch2 package to nix flake and test job to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,17 @@ jobs:
 
     - name: Check formatting
       run: nix develop --command bash -c "make check-format"
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install nix
+      uses: cachix/install-nix-action@v27
+      with: 
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Run unit tests
+      run: nix develop --command bash -c "make test-run"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Testing
 
-In order to run tests you should have a `catch2` test runner installed on your system with version `3.6.0`.
+In order to run tests you should have a `catch2` test runner installed on your system with version `3.7.0`.
 Then simply navigate to the project root folder and run the make target with name `test-run`
 
 ```shell

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
           pkgs.gcc
           pkgs.clang-tools
           pkgs.clang
+          pkgs.catch2_3
 
           pkgs.protobuf
           pkgs.pkg-config


### PR DESCRIPTION
I've added catch2 package to nix flake. It is unfortunately not `3.6.0`, but `3.7.0`, since it wasn't on `nixpkgs.unstable`. For sake of not building it from source every CI run I've included this slightly newer version. Since it's only one minor version different everything should work just fine on both used version.